### PR TITLE
Make namespace configurable via CB env vars

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ substitutions:
   _SERVICE_NAME: auth
   _SECRET_NAME: auth-private-key
   _DOMAIN: auth.${PROJECT_ID}.measurementlab.net
-  _CREDENTIALS_NS: platform-credentials
+  _PLATFORM_NS: platform-credentials
 steps:
   # 1. Build the container image
   - name: "gcr.io/cloud-builders/docker"
@@ -46,7 +46,7 @@ steps:
         "${_REGION}",
         "--allow-unauthenticated",
         "--set-secrets=/secrets/jwk-priv.json=${_SECRET_NAME}:latest",
-        "--set-env-vars=PROJECT_ID=${PROJECT_ID},CREDENTIALS_NAMESPACE=${_CREDENTIALS_NAMESPACE}",
+        "--set-env-vars=PROJECT_ID=${PROJECT_ID},PLATFORM_NS=${_PLATFORM_NS}",
         "--memory=256Mi",
         "--cpu=1",
         "--project=${PROJECT_ID}",

--- a/main.go
+++ b/main.go
@@ -21,15 +21,15 @@ import (
 )
 
 const (
-	jwkPrivKeyPath   = "/secrets/jwk-priv.json"
-	defaultNamespace = "platform-credentials"
-	defaultProjectID = "mlab-sandbox"
+	jwkPrivKeyPath    = "/secrets/jwk-priv.json"
+	defaultPlatformNS = "platform-credentials"
+	defaultProjectID  = "mlab-sandbox"
 )
 
 var (
 	port      = flag.Int("port", 8080, "Port to listen on")
 	keyPath   = flag.String("private-key-path", jwkPrivKeyPath, "Path to private key")
-	namespace = flag.String("credentials-ns", defaultNamespace,
+	namespace = flag.String("platform-ns", defaultPlatformNS,
 		"Datastore namespace for platform credentials")
 	projectID = flag.String("project-id", defaultProjectID, "Google Cloud project ID")
 )


### PR DESCRIPTION
..and default to a more generic "platform-credentials" name. Rationale: these credentials aren't specifically for autojoin, but for nodes and their components to access the M-Lab platform. There are at least two components that use or will use them: the `autojoin-register` client and the heartbeat client, which I'm going to migrate to token-exchange next.

Also, the naming scheme for the flag/env variable allows to add more credential databases in the future (e.g. `CLIENT_NS` for the client registration integrations' db).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/token-exchange/5)
<!-- Reviewable:end -->
